### PR TITLE
feat: request account, forget password, login, logout, edit account & change password.

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -24,10 +24,12 @@
         "react-router-dom": "^6.4.0",
         "react-scripts": "5.0.1",
         "typescript": "^4.8.3",
+        "validator": "^13.7.0",
         "web-vitals": "^2.1.4"
       },
       "devDependencies": {
         "@types/lodash": "^4.14.186",
+        "@types/validator": "^13.7.7",
         "sass": "^1.54.9"
       }
     },
@@ -4006,6 +4008,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "node_modules/@types/validator": {
+      "version": "13.7.7",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.7.tgz",
+      "integrity": "sha512-jiEw2kTUJ8Jsh4A1K4b5Pkjj9Xz6FktLLOQ36ZVLRkmxFbpTvAV2VRoKMojz8UlZxNg/2dZqzpigH4JYn1bkQg==",
+      "dev": true
     },
     "node_modules/@types/ws": {
       "version": "8.5.3",
@@ -16546,6 +16554,14 @@
         "node": ">=10.12.0"
       }
     },
+    "node_modules/validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw==",
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/vary": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
@@ -20228,6 +20244,12 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.2.tgz",
       "integrity": "sha512-F5DIZ36YVLE+PN+Zwws4kJogq47hNgX3Nx6WyDJ3kcplxyke3XIzB8uK5n/Lpm1HBsbGzd6nmGehL8cPekP+Tg=="
+    },
+    "@types/validator": {
+      "version": "13.7.7",
+      "resolved": "https://registry.npmjs.org/@types/validator/-/validator-13.7.7.tgz",
+      "integrity": "sha512-jiEw2kTUJ8Jsh4A1K4b5Pkjj9Xz6FktLLOQ36ZVLRkmxFbpTvAV2VRoKMojz8UlZxNg/2dZqzpigH4JYn1bkQg==",
+      "dev": true
     },
     "@types/ws": {
       "version": "8.5.3",
@@ -29151,6 +29173,11 @@
         "convert-source-map": "^1.6.0",
         "source-map": "^0.7.3"
       }
+    },
+    "validator": {
+      "version": "13.7.0",
+      "resolved": "https://registry.npmjs.org/validator/-/validator-13.7.0.tgz",
+      "integrity": "sha512-nYXQLCBkpJ8X6ltALua9dRrZDHVYxjJ1wgskNt1lH9fzGjs3tgojGSCBjmEPwkWS1y29+DrizMTW19Pr9uB2nw=="
     },
     "vary": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "react-router-dom": "^6.4.0",
     "react-scripts": "5.0.1",
     "typescript": "^4.8.3",
+    "validator": "^13.7.0",
     "web-vitals": "^2.1.4"
   },
   "scripts": {
@@ -47,6 +48,7 @@
   },
   "devDependencies": {
     "@types/lodash": "^4.14.186",
+    "@types/validator": "^13.7.7",
     "sass": "^1.54.9"
   }
 }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -24,14 +24,28 @@ const App = () => {
     <AuthState>
       <Router>
         <Layout style={{ height: '100vh' }}>
-          <AppHeader />
+          
           <Layout>
             <Routes>
               <Route path='/login' element={<Login />} />
               <Route
+                  path='/myAccount'
+                  element={
+                    <AuthRoute redirectTo='/login'>
+                      <Home>
+                        <ViewMyAccount />
+                      </Home>
+                    </AuthRoute>
+                  }
+                />
+
+              <Route
                 path='/'
                 element={
-                  <AuthRoute redirectTo='/login'>
+                  <AuthRoute
+                    redirectTo='/login'
+                    unverifiedRedirect='/myAccount'
+                  >
                     <Home />
                   </AuthRoute>
                 }
@@ -45,7 +59,10 @@ const App = () => {
                 {/* my orders routes */}
                 <Route path={ROOT_NAV_URLS.MY_ORDERS} element={<></>} />
                 {/* my profile routes */}
-                <Route path={ROOT_NAV_URLS.MY_ACCOUNT} element={<ViewMyAccount/>} />
+                <Route
+                  path={ROOT_NAV_URLS.MY_ACCOUNT}
+                  element={<ViewMyAccount />}
+                />
               </Route>
             </Routes>
           </Layout>

--- a/src/components/account/AccountEditGrid.tsx
+++ b/src/components/account/AccountEditGrid.tsx
@@ -1,0 +1,83 @@
+import { Form, Input } from 'antd';
+import { User } from '../../models/types';
+
+interface props {
+  editUser: User;
+  setEditUser: (user: any) => void;
+}
+
+const AccountEditGrid = ({ editUser, setEditUser }: props) => {
+  const userFieldOnChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    key: string
+  ) => {
+    setEditUser((paramUser: any) => {
+      return {
+        ...paramUser!,
+        [key]: event.target.value
+      };
+    });
+  };
+
+  return (
+    <Form
+      layout='vertical'
+      name='basic'
+      labelCol={{ span: 6 }}
+      initialValues={{ remember: true }}
+      autoComplete='off'
+    >
+      <Form.Item
+        label='First Name'
+        rules={[
+          { required: true, message: 'First name field cannot be empty!' }
+        ]}
+      >
+        <Input
+          value={editUser.firstName}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            userFieldOnChange(e, 'firstName');
+          }}
+        />
+      </Form.Item>
+      <Form.Item
+        label='Last Name'
+        rules={[
+          { required: true, message: 'Last name field cannot be empty!' }
+        ]}
+      >
+        <Input
+          value={editUser.lastName}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            userFieldOnChange(e, 'lastName');
+          }}
+        />
+      </Form.Item>
+      <Form.Item
+        label='Email Name'
+        rules={[
+          {
+            type: 'email',
+            message: 'The input is not valid E-mail!'
+          },
+          {
+            required: true,
+            message: 'Please input your E-mail!'
+          }
+        ]}
+      >
+        <Input
+          value={editUser.email}
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            userFieldOnChange(e, 'email');
+          }}
+        />
+      </Form.Item>
+      <Form.Item label='Role'>
+        <Input value={editUser.role} disabled />
+      </Form.Item>
+    </Form>
+  );
+};
+
+export default AccountEditGrid;

--- a/src/components/account/AccountInfoGrid.tsx
+++ b/src/components/account/AccountInfoGrid.tsx
@@ -1,0 +1,25 @@
+import { Col, Descriptions, Row, Typography } from 'antd';
+import { User } from '../../models/types';
+
+interface props {
+  user: User;
+}
+
+const AccountInfoGrid = ({ user }: props) => {
+  return (
+    <>
+      <Descriptions size='default' column={2}>
+        <Descriptions.Item label='First Name'>
+          {user?.firstName}
+        </Descriptions.Item>
+        <Descriptions.Item label='Last Name'>
+          {user?.lastName}
+        </Descriptions.Item>
+        <Descriptions.Item label='Email'>{user?.email}</Descriptions.Item>
+        <Descriptions.Item label='Role'>{user?.role} ({user?.status})</Descriptions.Item>
+      </Descriptions>
+    </>
+  );
+};
+
+export default AccountInfoGrid;

--- a/src/components/account/AccountMenu.tsx
+++ b/src/components/account/AccountMenu.tsx
@@ -1,0 +1,24 @@
+import { MoreOutlined } from '@ant-design/icons';
+import { Menu } from 'antd';
+
+interface props {
+  setEdit: () => void;
+  setOpenModal: () => void;
+}
+
+const AccountMenu = ({ setEdit, setOpenModal }: props) => {
+  return (
+    <Menu mode='horizontal'>
+      <Menu.SubMenu key='SubMenu' icon={<MoreOutlined />}>
+        <Menu.Item key='one' onClick={setEdit}>
+          Update Information
+        </Menu.Item>
+        <Menu.Item key='two' onClick={setOpenModal}>
+          Change Password
+        </Menu.Item>
+      </Menu.SubMenu>
+    </Menu>
+  );
+};
+
+export default AccountMenu;

--- a/src/components/account/AccountMenu.tsx
+++ b/src/components/account/AccountMenu.tsx
@@ -8,16 +8,18 @@ interface props {
 
 const AccountMenu = ({ setEdit, setOpenModal }: props) => {
   return (
-    <Menu mode='horizontal'>
-      <Menu.SubMenu key='SubMenu' icon={<MoreOutlined />}>
-        <Menu.Item key='one' onClick={setEdit}>
-          Update Information
-        </Menu.Item>
-        <Menu.Item key='two' onClick={setOpenModal}>
-          Change Password
-        </Menu.Item>
-      </Menu.SubMenu>
-    </Menu>
+    <>
+      <Menu mode='horizontal'>
+        <Menu.SubMenu key='SubMenu' icon={<MoreOutlined />}>
+          <Menu.Item key='one' onClick={setEdit}>
+            Update Information
+          </Menu.Item>
+          <Menu.Item key='two' onClick={setOpenModal}>
+            Change Password
+          </Menu.Item>
+        </Menu.SubMenu>
+      </Menu>
+    </>
   );
 };
 

--- a/src/components/account/EditButtonGroup.tsx
+++ b/src/components/account/EditButtonGroup.tsx
@@ -5,6 +5,7 @@ interface props {
   setEdit: (boolean: boolean) => void;
   edit: boolean;
   user: User;
+  editUser: User;
   setEditUser: (user: User) => void;
   handleSaveButtonClick: (e: any) => void;
 }
@@ -13,6 +14,7 @@ const EditButtonGroup = ({
   setEdit,
   edit,
   user,
+  editUser,
   setEditUser,
   handleSaveButtonClick
 }: props) => {
@@ -31,6 +33,7 @@ const EditButtonGroup = ({
         </Button>
         <Button
           type='primary'
+          disabled={!(editUser.email && editUser.firstName && editUser.lastName)}
           onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
             if (!edit) {
               setEdit(true);

--- a/src/components/account/EditButtonGroup.tsx
+++ b/src/components/account/EditButtonGroup.tsx
@@ -1,0 +1,50 @@
+import { Button, Space } from 'antd';
+import { User } from '../../models/types';
+
+interface props {
+  setEdit: (boolean: boolean) => void;
+  edit: boolean;
+  user: User;
+  setEditUser: (user: User) => void;
+  handleSaveButtonClick: (e: any) => void;
+}
+
+const EditButtonGroup = ({
+  setEdit,
+  edit,
+  user,
+  setEditUser,
+  handleSaveButtonClick
+}: props) => {
+  return (
+    <>
+      <Space>
+        <Button
+          className='create-btn'
+          color='primary'
+          onClick={() => {
+            setEdit(false);
+            user && setEditUser(user);
+          }}
+        >
+          DISCARD CHANGES
+        </Button>
+        <Button
+          type='primary'
+          onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
+            if (!edit) {
+              setEdit(true);
+            } else {
+              handleSaveButtonClick(e);
+              setEdit(false);
+            }
+          }}
+        >
+          SAVE CHANGES
+        </Button>
+      </Space>
+    </>
+  );
+};
+
+export default EditButtonGroup;

--- a/src/components/account/ForgetPasswordModal.tsx
+++ b/src/components/account/ForgetPasswordModal.tsx
@@ -1,0 +1,92 @@
+import { Modal, Button, Input, Space, Typography } from 'antd';
+import { useState } from 'react';
+import { forgetPasswordSvc } from '../../services/accountService';
+import asyncFetchCallback from '../../services/util/asyncFetchCallback';
+import TimeoutAlert, { AlertType } from '../common/TimeoutAlert';
+
+interface modalProps {
+  openPasswordModal: boolean;
+  handleClose: () => void;
+}
+
+const ForgetPasswordModal = ({
+  openPasswordModal,
+  handleClose
+}: modalProps) => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [recipientEmail, setRecipientEmail] = useState<string>('');
+  const [alert, setAlert] = useState<AlertType | null>(null);
+  const { Text } = Typography;
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    setRecipientEmail(e.target.value);
+  };
+
+  const handleForgetPassword = async () => {
+    console.log('recipientEmail', recipientEmail);
+    setLoading(true);
+    if (recipientEmail) {
+      await asyncFetchCallback(
+        forgetPasswordSvc(recipientEmail),
+        () => {
+          setLoading(false);
+          setAlert({
+            type: 'success',
+            message:
+              'A reset password email has been sent to your provided email.'
+          });
+        },
+        () => {
+          setLoading(false);
+          setAlert({
+            type: 'error',
+            message: 'Error resetting password. Try again later.'
+          });
+        }
+      );
+    }
+  };
+
+  return (
+    <Modal
+      open={openPasswordModal}
+      title='Forget Password'
+      onOk={handleForgetPassword}
+      onCancel={handleClose}
+      centered
+      footer={[
+        <Button key='back' onClick={handleClose}>
+          Close
+        </Button>,
+        <Button
+          key='submit'
+          type='primary'
+          loading={loading}
+          disabled={!recipientEmail}
+          onClick={handleForgetPassword}
+        >
+          Send Email
+        </Button>
+      ]}
+    >
+      <Space direction='vertical'>
+        {alert && (
+          <TimeoutAlert alert={alert} clearAlert={() => setAlert(null)} />
+        )}
+
+        <Typography>
+          Enter your login <Text strong>email</Text>. Instructions will be sent
+          to you to reset your password.
+        </Typography>
+
+        <Input
+          size='large'
+          placeholder='Enter email here...'
+          onChange={handleChange}
+        />
+      </Space>
+    </Modal>
+  );
+};
+
+export default ForgetPasswordModal;

--- a/src/components/account/RequestAccountModal.tsx
+++ b/src/components/account/RequestAccountModal.tsx
@@ -1,0 +1,188 @@
+import {
+  Modal,
+  Button,
+  Input,
+  Space,
+  Typography,
+  Form,
+  RadioChangeEvent,
+  Radio
+} from 'antd';
+import { useState } from 'react';
+import { User, UserRole } from '../../models/types';
+import { requestB2BUserSvc } from '../../services/accountService';
+import asyncFetchCallback from '../../services/util/asyncFetchCallback';
+import TimeoutAlert, { AlertType } from '../common/TimeoutAlert';
+
+interface modalProps {
+  reqAccountModal: boolean;
+  handleClose: () => void;
+}
+
+export type NewUserType = Partial<User>;
+
+const RequestAccountModal = ({ reqAccountModal, handleClose }: modalProps) => {
+  const [loading, setLoading] = useState<boolean>(false);
+  const [newUser, setNewUser] = useState<NewUserType>({});
+  const [alert, setAlert] = useState<AlertType | null>(null);
+
+  const handleReqButtonClick = (e: any) => {
+    setLoading(true);
+    if (
+      newUser.email &&
+      newUser.firstName &&
+      newUser.lastName &&
+      newUser.role
+    ) {
+      setLoading(true);
+      e.preventDefault();
+      asyncFetchCallback(
+        requestB2BUserSvc(newUser),
+        () => {
+          setNewUser({});
+          setAlert({
+            type: 'success',
+            message:
+              'Your request has been sent. We will contact you via email regarding your account approval.'
+          });
+          setLoading(false);
+        },
+        () => {
+          setAlert({
+            type: 'error',
+            message: 'Error requesting an account. Try again later.'
+          });
+          setLoading(false);
+        }
+      );
+    }
+  };
+
+  const userFieldOnChange = (
+    event: React.ChangeEvent<HTMLInputElement>,
+    key: string
+  ) => {
+    setNewUser((user: NewUserType) => {
+      return {
+        ...user,
+        [key]: event.target.value
+      };
+    });
+  };
+
+  const onChange = (e: RadioChangeEvent) => {
+    setNewUser((user: NewUserType) => {
+      return {
+        ...user,
+        role: e.target.value
+      };
+    });
+  };
+
+  const accountType = [
+    { label: 'Corporate', value: UserRole.CORPORATE },
+    { label: 'Distributor', value: UserRole.DISTRIBUTOR }
+  ];
+
+  return (
+    <Modal
+      open={reqAccountModal}
+      title='Request For Account'
+      onOk={handleReqButtonClick}
+      onCancel={handleClose}
+      centered
+      footer={[
+        <Button key='back' onClick={handleClose}>
+          Close
+        </Button>,
+        <Button
+          key='submit'
+          type='primary'
+          loading={loading}
+          onClick={handleReqButtonClick}
+          disabled={
+            !(
+              newUser.email &&
+              newUser.firstName &&
+              newUser.lastName &&
+              newUser.role
+            )
+          }
+        >
+          Request Account
+        </Button>
+      ]}
+    >
+      <Space direction='vertical'>
+        {alert && (
+          <TimeoutAlert alert={alert} clearAlert={() => setAlert(null)} />
+        )}
+        <Typography style={{ marginBottom: '5%' }}>
+          Enter your details here to request for an account. You will receive an
+          email when your request has been approved.
+        </Typography>
+        <Form
+          name='basic'
+          labelCol={{ span: 6 }}
+          wrapperCol={{ span: 16 }}
+          initialValues={{ remember: true }}
+          autoComplete='off'
+        >
+          <Form.Item
+            label='First Name'
+            name='firstName'
+            rules={[
+              { required: true, message: 'Please input your first name!' }
+            ]}
+          >
+            <Input
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                userFieldOnChange(e, 'firstName');
+              }}
+            />
+          </Form.Item>
+
+          <Form.Item
+            label='Last Name'
+            name='lastName'
+            rules={[
+              { required: true, message: 'Please input your last name!' }
+            ]}
+          >
+            <Input
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                userFieldOnChange(e, 'lastName');
+              }}
+            />
+          </Form.Item>
+
+          <Form.Item
+            label='Email'
+            name='email'
+            rules={[{ required: true, message: 'Please provide your email!' }]}
+          >
+            <Input
+              onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+                userFieldOnChange(e, 'email');
+              }}
+            />
+          </Form.Item>
+
+          <Form.Item
+            label='Role'
+            name='role'
+            rules={[{ required: true, message: 'Please chose your role.' }]}
+          >
+            <Radio.Group onChange={onChange}>
+              {accountType.map((account) => {
+                return <Radio value={account.value}>{account.label}</Radio>;
+              })}
+            </Radio.Group>
+          </Form.Item>
+        </Form>
+      </Space>
+    </Modal>
+  );
+};
+
+export default RequestAccountModal;

--- a/src/components/account/RequestAccountModal.tsx
+++ b/src/components/account/RequestAccountModal.tsx
@@ -159,7 +159,16 @@ const RequestAccountModal = ({ reqAccountModal, handleClose }: modalProps) => {
           <Form.Item
             label='Email'
             name='email'
-            rules={[{ required: true, message: 'Please provide your email!' }]}
+            rules={[
+              {
+                type: 'email',
+                message: 'The input is not valid E-mail!',
+              },
+              {
+                required: true,
+                message: 'Please input your E-mail!',
+              },
+            ]}
           >
             <Input
               onChange={(e: React.ChangeEvent<HTMLInputElement>) => {

--- a/src/components/auth/AuthRoute.tsx
+++ b/src/components/auth/AuthRoute.tsx
@@ -5,15 +5,26 @@ import AuthContext from '../../context/auth/authContext';
 type AuthRouteProps = {
   children: JSX.Element;
   redirectTo: string;
+  unverifiedRedirect?: string;
 };
 
-const AuthRoute = ({ children, redirectTo }: AuthRouteProps): JSX.Element => {
+const AuthRoute = ({ children, redirectTo, unverifiedRedirect }: AuthRouteProps): JSX.Element => {
   const authContext = useContext(AuthContext);
-  const { isAuthenticated } = authContext;
-
+  const { isAuthenticated, user } = authContext;
+  const verified = user?.isVerified ?? true;
 
   //TODO: set back conditional rendering to be based on isAuthenticated
-  return true ? children : <Navigate to={redirectTo} />;
+  // return true ? children : <Navigate to={redirectTo} />;
+
+  if (isAuthenticated) {
+    if (unverifiedRedirect) {
+      return verified ? children : <Navigate to={unverifiedRedirect} />;
+    } else {
+      return children;
+    }
+  } else {
+    return <Navigate to={redirectTo} />;
+  }
 };
 
 export default AuthRoute;

--- a/src/components/common/AppHeader.tsx
+++ b/src/components/common/AppHeader.tsx
@@ -34,7 +34,7 @@ const menuItems: MenuProps['items'] = [
   {
     label: <Link to={ROOT_NAV_URLS.MY_ORDERS}>My Orders</Link>,
     key: ROOT_NAV_URLS.MY_ORDERS
-  },
+  }
 ];
 
 const AppHeader = () => {
@@ -66,12 +66,12 @@ const AppHeader = () => {
             items={menuItems}
           />
 
-          <Menu mode='horizontal' theme='dark' >
+          <Menu mode='horizontal' theme='dark'>
             <Menu.SubMenu key='SubMenu' icon={<UserOutlined />}>
               <Menu.Item key='one'>
                 <Link to={ROOT_NAV_URLS.MY_ACCOUNT}>My Account</Link>
               </Menu.Item>
-              <Menu.Item key='two' onClick={logout}> 
+              <Menu.Item key='two' onClick={logout}>
                 Logout
               </Menu.Item>
             </Menu.SubMenu>

--- a/src/components/common/orders.ts
+++ b/src/components/common/orders.ts
@@ -1,0 +1,65 @@
+import { ColumnsType } from 'antd/lib/table';
+import { OrderStatus, PlatformType, SalesOrder } from '../../models/types';
+
+export const columns: ColumnsType<SalesOrder> = [
+  {
+    title: 'Ordered On',
+    dataIndex: 'createdTime',
+    key: 'createdTime'
+  },
+  {
+    title: 'Amount ($)',
+    dataIndex: 'amount',
+    key: 'amount'
+  },
+  {
+    title: 'Order Status',
+    dataIndex: 'orderStatus',
+    key: 'orderStatus'
+  },
+  {
+    title: 'Shipment Address',
+    dataIndex: 'customerAddress',
+    key: 'customerAddress'
+  },
+  {
+    title: 'Action',
+    key: 'action',
+    render: () => 'View'
+  }
+];
+
+export const data: SalesOrder[] = [
+  {
+    id: 1,
+    orderId: 'LAZ001',
+    customerName: 'Peter Tan',
+    customerAddress: 'Blk 123 NUS Road',
+    postalCode: '123456',
+    customerContactNo: '88889999',
+    customerEmail: 'petertan@email.com',
+    platformType: PlatformType.LAZADA,
+    createdTime: new Date(),
+    currency: 'SGD',
+    amount: 50,
+    orderStatus: OrderStatus.DELIVERED,
+    customerRemarks: 'No Spicy Thanks',
+    salesOrderItems: []
+  },
+  {
+    id: 2,
+    orderId: 'SHOPEE001',
+    customerName: 'Peter Tan',
+    customerAddress: 'Blk 123 NUS Road',
+    postalCode: '123456',
+    customerContactNo: '88889999',
+    customerEmail: 'petertan@email.com',
+    platformType: PlatformType.SHOPEE,
+    createdTime: new Date(),
+    currency: 'SGD',
+    amount: 85,
+    orderStatus: OrderStatus.SHIPPED,
+    customerRemarks: 'All spicy only',
+    salesOrderItems: []
+  }
+];

--- a/src/pages/Home.tsx
+++ b/src/pages/Home.tsx
@@ -4,6 +4,7 @@ import { Breadcrumb, Layout } from 'antd';
 import { Link, Location, Outlet, useLocation } from 'react-router-dom';
 import { FRONT_SLASH } from '../utils/constants';
 import { startCase } from 'lodash';
+import AppHeader from '../components/common/AppHeader';
 
 const { Content, Sider } = Layout;
 
@@ -35,6 +36,7 @@ const Home = ({ children }: HomeProps) => {
 
   return (
     <Content style={{ padding: '0 50px' }}>
+      <AppHeader />
       <Breadcrumb style={{ margin: '16px 0' }}>
         {getBreadcrumbItems(location)}
       </Breadcrumb>

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -17,6 +17,8 @@ import {
 import { Typography as AntTypography } from 'antd';
 import { LockOutlined, UserAddOutlined, UserOutlined } from '@ant-design/icons';
 import TimeoutAlert from '../components/common/TimeoutAlert';
+import ForgetPasswordModal from '../components/account/ForgetPasswordModal';
+import RequestAccountModal from '../components/account/RequestAccountModal';
 
 const { Title } = AntTypography;
 
@@ -47,6 +49,9 @@ const Login = () => {
     email: '',
     password: ''
   });
+  const [openPasswordModal, setOpenPasswordModal] =
+    React.useState<boolean>(false);
+  const [reqAccountModal, setReqAccountModal] = React.useState<boolean>(false);
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) =>
     setUserInput((prev: UserInput) => {
@@ -66,6 +71,14 @@ const Login = () => {
 
   return (
     <Content className='login-content'>
+      <ForgetPasswordModal
+        openPasswordModal={openPasswordModal}
+        handleClose={() => setOpenPasswordModal(false)}
+      />
+      <RequestAccountModal
+        reqAccountModal={reqAccountModal}
+        handleClose={() => setReqAccountModal(false)}
+      />
       <div className='login-container'>
         <div className='login-box'>
           <Image src={logo} width={250} preview={false} />
@@ -124,9 +137,15 @@ const Login = () => {
                   size='small'
                   icon={<UserAddOutlined />}
                   style={{ float: 'right', marginLeft: 10 }}
+                  onClick={() => setReqAccountModal(true)}
                 />
               </Tooltip>
-              <Button type='link' size='small' style={{ float: 'right' }}>
+              <Button
+                type='link'
+                size='small'
+                style={{ float: 'right' }}
+                onClick={() => setOpenPasswordModal(true)}
+              >
                 Forgot password
               </Button>
             </Form.Item>

--- a/src/pages/account/ChangePasswordModal.tsx
+++ b/src/pages/account/ChangePasswordModal.tsx
@@ -1,5 +1,5 @@
 import { EyeTwoTone, EyeInvisibleOutlined } from '@ant-design/icons';
-import { Modal, Button, Input, Space } from 'antd';
+import { Modal, Button, Input, Space, Form } from 'antd';
 import { useState } from 'react';
 import { User } from '../../models/types';
 import { updatePasswordSvc } from '../../services/accountService';
@@ -25,9 +25,6 @@ const ChangePasswordModal = ({
   const [currentPassword, setCurrentPassword] = useState<string>('');
   const [newPassword, setNewPassword] = useState<string>('');
   const [confirmPassword, setConfirmPassword] = useState<string>('');
-  const [showCurrPwdError, setShowCurrPwdError] = useState<boolean>(false);
-  const [showNewPwdError, setShowNewPwdError] = useState<boolean>(false);
-  const [showCfmPwdError, setShowCfmPwdError] = useState<boolean>(false);
 
   const updatePassword = (e: any) => {
     e.preventDefault();
@@ -39,9 +36,6 @@ const ChangePasswordModal = ({
         setCurrentPassword('');
         setNewPassword('');
         setConfirmPassword('');
-        setShowNewPwdError(false);
-        setShowCurrPwdError(false);
-        setShowCfmPwdError(false);
         loadUser();
       },
       (err) => {
@@ -53,6 +47,7 @@ const ChangePasswordModal = ({
 
   return (
     <Modal
+      width={600}
       open={open}
       title='Change Password'
       onOk={handleSubmit}
@@ -66,50 +61,82 @@ const ChangePasswordModal = ({
           type='primary'
           loading={loading}
           onClick={updatePassword}
+          disabled={
+            currentPassword === newPassword || newPassword !== confirmPassword
+          }
         >
           Update Password
         </Button>
       ]}
     >
       <Space direction='vertical'>
-        <Input.Password
-          onChange={(e: any) => {
-            setCurrentPassword(e.target.value);
-            setShowCurrPwdError(true);
-          }}
-          style={{ width: '100%' }}
-          placeholder='Current Password'
-          iconRender={(visible) =>
-            visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
-          }
-        />
-        <Input.Password
-          status={
-            (newPassword === currentPassword ||
-              validator.isEmpty(currentPassword)) &&
-            showNewPwdError
-              ? 'error'
-              : ''
-          }
-          onChange={(e: any) => {
-            setNewPassword(e.target.value);
-            setShowNewPwdError(true);
-          }}
-          placeholder='New Password'
-          iconRender={(visible) =>
-            visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
-          }
-        />
-        <Input.Password
-          onChange={(e: any) => {
-            setConfirmPassword(e.target.value);
-            setShowCfmPwdError(true);
-          }}
-          placeholder='Confirm New Password'
-          iconRender={(visible) =>
-            visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
-          }
-        />
+        <Form
+          name='basic'
+          labelCol={{ span: 10 }}
+          initialValues={{ remember: true }}
+          autoComplete='off'
+        >
+          <Form.Item
+            label='Current Password'
+            name='currentPassword'
+            rules={[
+              {
+                required: true,
+                message: 'Please input your current password!'
+              }
+            ]}
+          >
+            <Input.Password
+              onChange={(e: any) => {
+                setCurrentPassword(e.target.value);
+              }}
+              placeholder='Current Password'
+              iconRender={(visible) =>
+                visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
+              }
+            />
+          </Form.Item>
+          <Form.Item
+            label='New Password'
+            name='newPassword'
+            rules={[
+              {
+                required: true,
+                message: 'Please input a new password!'
+              }
+            ]}
+          >
+            <Input.Password
+              onChange={(e: any) => {
+                setNewPassword(e.target.value);
+              }}
+              placeholder='New Password'
+              iconRender={(visible) =>
+                visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
+              }
+            />
+          </Form.Item>
+          <Form.Item
+            label='Confirm Password'
+            name='confirmPassword'
+            rules={[
+              {
+                required: true,
+                message: 'Please input the new password again!'
+              }
+            ]}
+          >
+            <Input.Password
+              onChange={(e: any) => {
+                setConfirmPassword(e.target.value);
+              }}
+              placeholder='Confirm New Password'
+              iconRender={(visible) =>
+                visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
+              }
+            />
+          </Form.Item>
+        </Form>
       </Space>
     </Modal>
   );

--- a/src/pages/account/ChangePasswordModal.tsx
+++ b/src/pages/account/ChangePasswordModal.tsx
@@ -1,0 +1,118 @@
+import { EyeTwoTone, EyeInvisibleOutlined } from '@ant-design/icons';
+import { Modal, Button, Input, Space } from 'antd';
+import { useState } from 'react';
+import { User } from '../../models/types';
+import { updatePasswordSvc } from '../../services/accountService';
+import asyncFetchCallback from '../../services/util/asyncFetchCallback';
+import validator from 'validator';
+
+interface props {
+  open: boolean;
+  handleCancel: () => void;
+  handleSubmit: () => void;
+  user: User;
+  loadUser: () => void;
+}
+
+const ChangePasswordModal = ({
+  open,
+  handleCancel,
+  handleSubmit,
+  user,
+  loadUser
+}: props) => {
+  const [loading, setLoading] = useState(false);
+  const [currentPassword, setCurrentPassword] = useState<string>('');
+  const [newPassword, setNewPassword] = useState<string>('');
+  const [confirmPassword, setConfirmPassword] = useState<string>('');
+  const [showCurrPwdError, setShowCurrPwdError] = useState<boolean>(false);
+  const [showNewPwdError, setShowNewPwdError] = useState<boolean>(false);
+  const [showCfmPwdError, setShowCfmPwdError] = useState<boolean>(false);
+
+  const updatePassword = (e: any) => {
+    e.preventDefault();
+    setLoading(true);
+    asyncFetchCallback(
+      updatePasswordSvc(user?.email!, currentPassword, newPassword),
+      () => {
+        setLoading(false);
+        setCurrentPassword('');
+        setNewPassword('');
+        setConfirmPassword('');
+        setShowNewPwdError(false);
+        setShowCurrPwdError(false);
+        setShowCfmPwdError(false);
+        loadUser();
+      },
+      (err) => {
+        //Catch error and log
+        setLoading(false);
+      }
+    );
+  };
+
+  return (
+    <Modal
+      open={open}
+      title='Change Password'
+      onOk={handleSubmit}
+      onCancel={handleCancel}
+      footer={[
+        <Button key='back' onClick={handleCancel}>
+          Return
+        </Button>,
+        <Button
+          key='submit'
+          type='primary'
+          loading={loading}
+          onClick={updatePassword}
+        >
+          Update Password
+        </Button>
+      ]}
+    >
+      <Space direction='vertical'>
+        <Input.Password
+          onChange={(e: any) => {
+            setCurrentPassword(e.target.value);
+            setShowCurrPwdError(true);
+          }}
+          style={{ width: '100%' }}
+          placeholder='Current Password'
+          iconRender={(visible) =>
+            visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
+          }
+        />
+        <Input.Password
+          status={
+            (newPassword === currentPassword ||
+              validator.isEmpty(currentPassword)) &&
+            showNewPwdError
+              ? 'error'
+              : ''
+          }
+          onChange={(e: any) => {
+            setNewPassword(e.target.value);
+            setShowNewPwdError(true);
+          }}
+          placeholder='New Password'
+          iconRender={(visible) =>
+            visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
+          }
+        />
+        <Input.Password
+          onChange={(e: any) => {
+            setConfirmPassword(e.target.value);
+            setShowCfmPwdError(true);
+          }}
+          placeholder='Confirm New Password'
+          iconRender={(visible) =>
+            visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
+          }
+        />
+      </Space>
+    </Modal>
+  );
+};
+
+export default ChangePasswordModal;

--- a/src/pages/account/ViewMyAccount.tsx
+++ b/src/pages/account/ViewMyAccount.tsx
@@ -1,16 +1,17 @@
 import { LoadingOutlined } from '@ant-design/icons';
-import { Descriptions, Table, Typography } from 'antd';
+import { Typography } from 'antd';
 import '../../styles/pages/account.scss';
 import React, { useState } from 'react';
 import authContext from '../../context/auth/authContext';
 import { User } from '../../models/types';
 import { editUserSvc } from '../../services/accountService';
-import { columns, data } from '../../components/common/orders';
 import asyncFetchCallback from '../../services/util/asyncFetchCallback';
 import AccountMenu from '../../components/account/AccountMenu';
 import EditButtonGroup from '../../components/account/EditButtonGroup';
 import ChangePasswordModal from './ChangePasswordModal';
 import TimeoutAlert from '../../components/common/TimeoutAlert';
+import AccountInfoGrid from '../../components/account/AccountInfoGrid';
+import AccountEditGrid from '../../components/account/AccountEditGrid';
 const { Title } = Typography;
 
 const ViewMyAccount = () => {
@@ -24,6 +25,9 @@ const ViewMyAccount = () => {
 
   React.useEffect(() => {
     if (user) {
+      if(!user.isVerified) {
+        setOpenModal(true);
+      }
       setEditUser(user);
     }
   }, [user]);
@@ -61,6 +65,7 @@ const ViewMyAccount = () => {
               setEdit={setEdit}
               edit={edit}
               user={user!}
+              editUser={editUser!}
               setEditUser={setEditUser}
               handleSaveButtonClick={handleSaveButtonClick}
             />
@@ -80,13 +85,7 @@ const ViewMyAccount = () => {
           clearAlert={() => setError('')}
         />
       )}
-      <Descriptions size='default' column={2}>
-        <Descriptions.Item label='First Name'>Tan</Descriptions.Item>
-        <Descriptions.Item label='Last Name'>Wee Kek</Descriptions.Item>
-        <Descriptions.Item label='Email'>tanwk@email.com</Descriptions.Item>
-        <Descriptions.Item label='Role'>Distributor</Descriptions.Item>
-      </Descriptions>
-      {/* <Table columns={columns} dataSource={data} />; */}
+          {edit ? <AccountEditGrid editUser={editUser!} setEditUser={setEditUser}/>: <AccountInfoGrid user={user!}/>}
     </>
   );
 };

--- a/src/pages/account/ViewMyAccount.tsx
+++ b/src/pages/account/ViewMyAccount.tsx
@@ -9,7 +9,7 @@ import asyncFetchCallback from '../../services/util/asyncFetchCallback';
 import AccountMenu from '../../components/account/AccountMenu';
 import EditButtonGroup from '../../components/account/EditButtonGroup';
 import ChangePasswordModal from './ChangePasswordModal';
-import TimeoutAlert from '../../components/common/TimeoutAlert';
+import TimeoutAlert, { AlertType } from '../../components/common/TimeoutAlert';
 import AccountInfoGrid from '../../components/account/AccountInfoGrid';
 import AccountEditGrid from '../../components/account/AccountEditGrid';
 const { Title } = Typography;
@@ -21,11 +21,11 @@ const ViewMyAccount = () => {
   const [edit, setEdit] = useState<boolean>(false);
   const [openModal, setOpenModal] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
-  const [error, setError] = useState<string>('');
+  const [alert, setAlert] = useState<AlertType | null>(null);
 
   React.useEffect(() => {
     if (user) {
-      if(!user.isVerified) {
+      if (!user.isVerified) {
         setOpenModal(true);
       }
       setEditUser(user);
@@ -39,9 +39,19 @@ const ViewMyAccount = () => {
       editUserSvc(editUser!),
       () => {
         setLoading(false);
+        setAlert({
+          type: 'success',
+          message:
+            'Edits to your account has been saved.'
+        });
         loadUser();
       },
       () => {
+        setAlert({
+          type: 'error',
+          message:
+            'Failed to save changes. Contact the admin.'
+        });
         setLoading(false);
       }
     );
@@ -76,16 +86,14 @@ const ViewMyAccount = () => {
           />
         </div>
       </div>
-      {error && (
-        <TimeoutAlert
-          alert={{
-            type: 'error',
-            message: error
-          }}
-          clearAlert={() => setError('')}
-        />
+      {alert && (
+        <TimeoutAlert alert={alert} clearAlert={() => setAlert(null)} />
       )}
-          {edit ? <AccountEditGrid editUser={editUser!} setEditUser={setEditUser}/>: <AccountInfoGrid user={user!}/>}
+      {edit ? (
+        <AccountEditGrid editUser={editUser!} setEditUser={setEditUser} />
+      ) : (
+        <AccountInfoGrid user={user!} />
+      )}
     </>
   );
 };

--- a/src/pages/account/ViewMyAccount.tsx
+++ b/src/pages/account/ViewMyAccount.tsx
@@ -1,15 +1,16 @@
-import {
-  EyeTwoTone,
-  EyeInvisibleOutlined,
-  LoadingOutlined
-} from '@ant-design/icons';
-import { Button, Collapse, Descriptions, Input, Space, Typography } from 'antd';
+import { LoadingOutlined } from '@ant-design/icons';
+import { Descriptions, Table, Typography } from 'antd';
 import '../../styles/pages/account.scss';
 import React, { useState } from 'react';
 import authContext from '../../context/auth/authContext';
 import { User } from '../../models/types';
 import { editUserSvc } from '../../services/accountService';
-const { Panel } = Collapse;
+import { columns, data } from '../../components/common/orders';
+import asyncFetchCallback from '../../services/util/asyncFetchCallback';
+import AccountMenu from '../../components/account/AccountMenu';
+import EditButtonGroup from '../../components/account/EditButtonGroup';
+import ChangePasswordModal from './ChangePasswordModal';
+import TimeoutAlert from '../../components/common/TimeoutAlert';
 const { Title } = Typography;
 
 const ViewMyAccount = () => {
@@ -17,7 +18,9 @@ const ViewMyAccount = () => {
   const { user, loadUser } = authhenticationContext;
   const [editUser, setEditUser] = useState<User>();
   const [edit, setEdit] = useState<boolean>(false);
+  const [openModal, setOpenModal] = useState<boolean>(false);
   const [loading, setLoading] = useState<boolean>(false);
+  const [error, setError] = useState<string>('');
 
   React.useEffect(() => {
     if (user) {
@@ -42,76 +45,50 @@ const ViewMyAccount = () => {
 
   return (
     <>
+      <ChangePasswordModal
+        open={openModal}
+        handleCancel={() => setOpenModal(false)}
+        handleSubmit={() => setOpenModal(false)}
+        loadUser={() => loadUser()}
+        user={user!}
+      />
       <div className='account-header-group'>
-        <Title level={2}>Your Profile Page</Title>
+        <Title level={1}>Your Profile Page</Title>
         <div className='button-group'>
           {loading && <LoadingOutlined />}
           {edit && (
-            <Button
-              className='create-btn'
-              color='primary'
-              onClick={() => {
-                setEdit(false);
-                user && setEditUser(user);
-              }}
-            >
-              DISCARD CHANGES
-            </Button>
+            <EditButtonGroup
+              setEdit={setEdit}
+              edit={edit}
+              user={user!}
+              setEditUser={setEditUser}
+              handleSaveButtonClick={handleSaveButtonClick}
+            />
           )}
-          <Button
-            type='primary'
-            onClick={(e: React.MouseEvent<HTMLButtonElement>) => {
-              if (!edit) {
-                setEdit(true);
-              } else {
-                handleSaveButtonClick(e);
-                setEdit(false);
-              }
-            }}
-          >
-            {edit ? 'SAVE CHANGES' : 'EDIT'}
-          </Button>
+          <AccountMenu
+            setEdit={() => setEdit(true)}
+            setOpenModal={() => setOpenModal(true)}
+          />
         </div>
       </div>
-
+      {error && (
+        <TimeoutAlert
+          alert={{
+            type: 'error',
+            message: error
+          }}
+          clearAlert={() => setError('')}
+        />
+      )}
       <Descriptions size='default' column={2}>
         <Descriptions.Item label='First Name'>Tan</Descriptions.Item>
         <Descriptions.Item label='Last Name'>Wee Kek</Descriptions.Item>
         <Descriptions.Item label='Email'>tanwk@email.com</Descriptions.Item>
         <Descriptions.Item label='Role'>Distributor</Descriptions.Item>
       </Descriptions>
-
-      <Collapse accordion>
-        <Panel header='Change Password' key='1'>
-          <Space direction='vertical'>
-            <Input.Password
-              style={{ width: '100%' }}
-              placeholder='Current Password'
-              iconRender={(visible) =>
-                visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
-              }
-            />
-            <Input.Password
-              placeholder='New Password'
-              iconRender={(visible) =>
-                visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
-              }
-            />
-            <Input.Password
-              placeholder='Confirm New Password'
-              iconRender={(visible) =>
-                visible ? <EyeTwoTone /> : <EyeInvisibleOutlined />
-              }
-            />
-            <Button type='primary'>Update Password</Button>
-          </Space>
-        </Panel>
-      </Collapse>
+      {/* <Table columns={columns} dataSource={data} />; */}
     </>
   );
 };
 
 export default ViewMyAccount;
-function asyncFetchCallback(arg0: any, arg1: () => void, arg2: () => void) {
-  throw new Error('Function not implemented.');
-}

--- a/src/services/accountService.ts
+++ b/src/services/accountService.ts
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { NewUserType } from '../components/account/RequestAccountModal';
 import { User } from '../models/types';
 import apiRoot from './util/apiRoot';
 
@@ -8,6 +9,10 @@ export const getUserDetailsSvc = (userId: string): Promise<User> => {
 
 export const editUserSvc = (user: User): Promise<any> => {
   return axios.put(`${apiRoot}/user`, user).then((res) => res.data);
+};
+
+export const requestB2BUserSvc = (user: NewUserType): Promise<any> => {
+  return axios.post(`${apiRoot}/user`, user).then((res) => res.data);
 };
 
 export const updatePasswordSvc = (
@@ -21,5 +26,11 @@ export const updatePasswordSvc = (
       currentPassword,
       newPassword
     })
+    .then((res) => res.data);
+};
+
+export const forgetPasswordSvc = (recipientEmail: string): Promise<any> => {
+  return axios
+    .post(`${apiRoot}/user/forgetpw`, { recipientEmail })
     .then((res) => res.data);
 };

--- a/src/services/accountService.ts
+++ b/src/services/accountService.ts
@@ -9,3 +9,17 @@ export const getUserDetailsSvc = (userId: string): Promise<User> => {
 export const editUserSvc = (user: User): Promise<any> => {
   return axios.put(`${apiRoot}/user`, user).then((res) => res.data);
 };
+
+export const updatePasswordSvc = (
+  userEmail: string,
+  currentPassword: string,
+  newPassword: string
+): Promise<any> => {
+  return axios
+    .post(`${apiRoot}/user/updatepw`, {
+      userEmail,
+      currentPassword,
+      newPassword
+    })
+    .then((res) => res.data);
+};

--- a/src/styles/pages/account.scss
+++ b/src/styles/pages/account.scss
@@ -1,12 +1,13 @@
 .account-header-group {
-    width: 100%;
-    display: flex;
-    flex-direction: row;
-    justify-content: space-between;
-    align-items: baseline;
+  width: 100%;
+  display: flex;
+  flex-direction: row;
+  justify-content: space-between;
+  align-items: baseline;
 }
 
-.button-group{
-    display: flex;
-    justify-content: flex-end;
+.button-group {
+  display: flex;
+  justify-content: flex-end;
+  align-items: center;
 }


### PR DESCRIPTION
feat: added request-for-account modal, new b2b users can request for an account. Requests are managed on ERP FE.
feat: added forget password modal, flow is similar to ERP forget password user-flow.
feat: linked up login from AuthRoute and AuthState. Will route to profile page when users are first-time login (User.isVerified===false)
feat: done up edit account details (firstname, lastname & email only)
feat: done up change password modal.

todo: 
fix issue where refresh = logged out.
for appbar, need to push profile icon to right side of bar.