### PR TITLE
Removed role (b2b) from account info grid

### DIFF
--- a/src/components/account/AccountInfoGrid.tsx
+++ b/src/components/account/AccountInfoGrid.tsx
@@ -25,9 +25,6 @@ const AccountInfoGrid = ({ user }: props) => {
         <Card title='Email' size='small'>
           <Typography>{user?.email}</Typography>
         </Card>
-        <Card title='Role' size='small'>
-          <Typography>{_.startCase(user?.role.toString().toLowerCase())}</Typography>
-        </Card>
       </Space>
     </>
   );


### PR DESCRIPTION
fix: removed role information from personal account page